### PR TITLE
Allow slot syntax

### DIFF
--- a/src/skip-to.vue
+++ b/src/skip-to.vue
@@ -1,5 +1,7 @@
 <template>
-  <a class="vue-skip-to" :href="to" :tabindex="tabindex" v-text="text"></a>
+  <a class="vue-skip-to" :href="to" :tabindex="tabindex">
+    <slot>{{ text }}</slot>
+  </a>
 </template>
 
 <script>


### PR DESCRIPTION
allows users to make use of vue's slot syntax without inhibiting use of 'v-text' attribute (as discussed in #2)