### PR TITLE
Update 'How to use' section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ import Vue from 'vue'
 import VueSkipTo from 'vue-skip-to'
 
 Vue.use(VueSkipTo)
+
+new Vue({
+  //... options
+})
 ```
 
 In your `App.vue`


### PR DESCRIPTION
I wanted to add this detail for people that aren't aware of Vue's rules with plugins defined [here](https://vuejs.org/v2/guide/plugins.html#Using-a-Plugin).

A colleage of mine made the mistake of using `Vue.use()` after `new Vue()` in the main.js and it caused the following error. 
```
[Vue warn]: Unknown custom element: <vue-skip-to> - did you register the component correctly? For recursive components, make sure to provide the "name" option. found in ---> <App> at src/App.vue <Root>
```
Fingers crossed that this helps others dodge this mistake.